### PR TITLE
Fix editor 'reset theme' button

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -1467,7 +1467,7 @@ window.importTheme = function () {
 }
 
 window.resetTheme = function () {
-  deserializeTheme(puzzle, 'vt1_AP---wDW1tYAs7Oz~6ABwcHAAxMTEAP---wCI--8A--8iAA__');
+  deserializeTheme(puzzle, 'vt1_~5-.7u7v.qqqr-~4A-zMzM--MzMz~6-4j~6-yL-~6A__');
   applyThemeButton();
   applyImageButton();
   writePuzzle();


### PR DESCRIPTION
Must be leftover from smth. This one works. Same values for everything as the default.